### PR TITLE
Prepare building phase using sourcery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ outputs/*
 
 # ENV files
 .env
+env-vars.sh
 
 # Generated files
-
+*.generated.swift

--- a/GitHubUsers.xcodeproj/project.pbxproj
+++ b/GitHubUsers.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09C3A65388E1D7F3ABC1B04A /* Pods_GitHubUsersTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1E451BE788102C1C4858679 /* Pods_GitHubUsersTests.framework */; };
+		5F4D977F26DBF333EDCAA16D /* Pods_GitHubUsers_GitHubUsersUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D817333E3DBEFF4D35EC30C4 /* Pods_GitHubUsers_GitHubUsersUITests.framework */; };
 		C17C4E712E0F93A2009D76F4 /* GitHubUsersApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */; };
 		C17C4E732E0F93A2009D76F4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E722E0F93A2009D76F4 /* ContentView.swift */; };
 		C17C4E752E0F93A2009D76F4 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E742E0F93A2009D76F4 /* Item.swift */; };
@@ -15,6 +17,7 @@
 		C17C4E842E0F93A4009D76F4 /* GitHubUsersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E832E0F93A4009D76F4 /* GitHubUsersTests.swift */; };
 		C17C4E8E2E0F93A4009D76F4 /* GitHubUsersUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E8D2E0F93A4009D76F4 /* GitHubUsersUITests.swift */; };
 		C17C4E902E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E8F2E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift */; };
+		CE39E318BECF35D575CF9628 /* Pods_GitHubUsers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE01B523E7528C955411C22 /* Pods_GitHubUsers.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +38,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1264A37289011F4C0A1F5195 /* Pods-GitHubUsersTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsersTests.release.xcconfig"; path = "Target Support Files/Pods-GitHubUsersTests/Pods-GitHubUsersTests.release.xcconfig"; sourceTree = "<group>"; };
+		217B66196A0803D5F045CA0E /* Pods-GitHubUsers.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsers.release.xcconfig"; path = "Target Support Files/Pods-GitHubUsers/Pods-GitHubUsers.release.xcconfig"; sourceTree = "<group>"; };
+		3AE01B523E7528C955411C22 /* Pods_GitHubUsers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GitHubUsers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		879209BCB59B2401AAD83D97 /* Pods-GitHubUsersTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsersTests.debug.xcconfig"; path = "Target Support Files/Pods-GitHubUsersTests/Pods-GitHubUsersTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B2600C066F3FB01A84A65693 /* Pods-GitHubUsers.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsers.debug.xcconfig"; path = "Target Support Files/Pods-GitHubUsers/Pods-GitHubUsers.debug.xcconfig"; sourceTree = "<group>"; };
 		C17C4E6D2E0F93A2009D76F4 /* GitHubUsers.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHubUsers.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersApp.swift; sourceTree = "<group>"; };
 		C17C4E722E0F93A2009D76F4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -46,6 +54,10 @@
 		C17C4E892E0F93A4009D76F4 /* GitHubUsersUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitHubUsersUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C17C4E8D2E0F93A4009D76F4 /* GitHubUsersUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersUITests.swift; sourceTree = "<group>"; };
 		C17C4E8F2E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D5AE30B1A987C8164ECA901C /* Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig"; path = "Target Support Files/Pods-GitHubUsers-GitHubUsersUITests/Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig"; sourceTree = "<group>"; };
+		D817333E3DBEFF4D35EC30C4 /* Pods_GitHubUsers_GitHubUsersUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GitHubUsers_GitHubUsersUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1E451BE788102C1C4858679 /* Pods_GitHubUsersTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GitHubUsersTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FE66373EF0A26025AE5F217F /* Pods-GitHubUsers-GitHubUsersUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsers-GitHubUsersUITests.debug.xcconfig"; path = "Target Support Files/Pods-GitHubUsers-GitHubUsersUITests/Pods-GitHubUsers-GitHubUsersUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE39E318BECF35D575CF9628 /* Pods_GitHubUsers.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09C3A65388E1D7F3ABC1B04A /* Pods_GitHubUsersTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,12 +81,26 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F4D977F26DBF333EDCAA16D /* Pods_GitHubUsers_GitHubUsersUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		54F87D011D800652757ECABC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B2600C066F3FB01A84A65693 /* Pods-GitHubUsers.debug.xcconfig */,
+				217B66196A0803D5F045CA0E /* Pods-GitHubUsers.release.xcconfig */,
+				FE66373EF0A26025AE5F217F /* Pods-GitHubUsers-GitHubUsersUITests.debug.xcconfig */,
+				D5AE30B1A987C8164ECA901C /* Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig */,
+				879209BCB59B2401AAD83D97 /* Pods-GitHubUsersTests.debug.xcconfig */,
+				1264A37289011F4C0A1F5195 /* Pods-GitHubUsersTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		C17C4E642E0F93A2009D76F4 = {
 			isa = PBXGroup;
 			children = (
@@ -80,6 +108,8 @@
 				C17C4E822E0F93A4009D76F4 /* GitHubUsersTests */,
 				C17C4E8C2E0F93A4009D76F4 /* GitHubUsersUITests */,
 				C17C4E6E2E0F93A2009D76F4 /* Products */,
+				54F87D011D800652757ECABC /* Pods */,
+				DC2AB645CA1E5DCCC5ED6E23 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -96,6 +126,7 @@
 		C17C4E6F2E0F93A2009D76F4 /* GitHubUsers */ = {
 			isa = PBXGroup;
 			children = (
+				C17C4E9D2E0FA2FC009D76F4 /* Helpers */,
 				C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */,
 				C17C4E722E0F93A2009D76F4 /* ContentView.swift */,
 				C17C4E742E0F93A2009D76F4 /* Item.swift */,
@@ -130,6 +161,23 @@
 			path = GitHubUsersUITests;
 			sourceTree = "<group>";
 		};
+		C17C4E9D2E0FA2FC009D76F4 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		DC2AB645CA1E5DCCC5ED6E23 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3AE01B523E7528C955411C22 /* Pods_GitHubUsers.framework */,
+				D817333E3DBEFF4D35EC30C4 /* Pods_GitHubUsers_GitHubUsersUITests.framework */,
+				F1E451BE788102C1C4858679 /* Pods_GitHubUsersTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -137,6 +185,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C17C4E932E0F93A4009D76F4 /* Build configuration list for PBXNativeTarget "GitHubUsers" */;
 			buildPhases = (
+				7F3A1037E7EA2BCB94E78A35 /* [CP] Check Pods Manifest.lock */,
 				C17C4E692E0F93A2009D76F4 /* Sources */,
 				C17C4E6A2E0F93A2009D76F4 /* Frameworks */,
 				C17C4E6B2E0F93A2009D76F4 /* Resources */,
@@ -154,6 +203,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C17C4E962E0F93A4009D76F4 /* Build configuration list for PBXNativeTarget "GitHubUsersTests" */;
 			buildPhases = (
+				C8C2ED3CD2501C85B2CC1B9B /* [CP] Check Pods Manifest.lock */,
 				C17C4E7B2E0F93A4009D76F4 /* Sources */,
 				C17C4E7C2E0F93A4009D76F4 /* Frameworks */,
 				C17C4E7D2E0F93A4009D76F4 /* Resources */,
@@ -172,6 +222,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C17C4E992E0F93A4009D76F4 /* Build configuration list for PBXNativeTarget "GitHubUsersUITests" */;
 			buildPhases = (
+				ACFD6DBF3F954D7F57BF34E5 /* [CP] Check Pods Manifest.lock */,
 				C17C4E852E0F93A4009D76F4 /* Sources */,
 				C17C4E862E0F93A4009D76F4 /* Frameworks */,
 				C17C4E872E0F93A4009D76F4 /* Resources */,
@@ -254,6 +305,75 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		7F3A1037E7EA2BCB94E78A35 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GitHubUsers-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ACFD6DBF3F954D7F57BF34E5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GitHubUsers-GitHubUsersUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C8C2ED3CD2501C85B2CC1B9B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GitHubUsersTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C17C4E692E0F93A2009D76F4 /* Sources */ = {
@@ -420,6 +540,7 @@
 		};
 		C17C4E942E0F93A4009D76F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B2600C066F3FB01A84A65693 /* Pods-GitHubUsers.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -427,6 +548,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GitHubUsers/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -448,6 +570,7 @@
 		};
 		C17C4E952E0F93A4009D76F4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 217B66196A0803D5F045CA0E /* Pods-GitHubUsers.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -455,6 +578,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GitHubUsers/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -476,6 +600,7 @@
 		};
 		C17C4E972E0F93A4009D76F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 879209BCB59B2401AAD83D97 /* Pods-GitHubUsersTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -495,6 +620,7 @@
 		};
 		C17C4E982E0F93A4009D76F4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1264A37289011F4C0A1F5195 /* Pods-GitHubUsersTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -514,6 +640,7 @@
 		};
 		C17C4E9A2E0F93A4009D76F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FE66373EF0A26025AE5F217F /* Pods-GitHubUsers-GitHubUsersUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -531,6 +658,7 @@
 		};
 		C17C4E9B2E0F93A4009D76F4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5AE30B1A987C8164ECA901C /* Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/GitHubUsers.xcodeproj/project.pbxproj
+++ b/GitHubUsers.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		C17C4E842E0F93A4009D76F4 /* GitHubUsersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E832E0F93A4009D76F4 /* GitHubUsersTests.swift */; };
 		C17C4E8E2E0F93A4009D76F4 /* GitHubUsersUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E8D2E0F93A4009D76F4 /* GitHubUsersUITests.swift */; };
 		C17C4E902E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E8F2E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift */; };
+		C17C4EA62E0FAFBC009D76F4 /* APIConfig.stencil in Resources */ = {isa = PBXBuildFile; fileRef = C17C4EA52E0FAFBC009D76F4 /* APIConfig.stencil */; };
+		C17C4EA82E0FAFD1009D76F4 /* APIConfig.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4EA72E0FAFD1009D76F4 /* APIConfig.generated.swift */; };
 		CE39E318BECF35D575CF9628 /* Pods_GitHubUsers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE01B523E7528C955411C22 /* Pods_GitHubUsers.framework */; };
 /* End PBXBuildFile section */
 
@@ -54,6 +56,8 @@
 		C17C4E892E0F93A4009D76F4 /* GitHubUsersUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitHubUsersUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C17C4E8D2E0F93A4009D76F4 /* GitHubUsersUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersUITests.swift; sourceTree = "<group>"; };
 		C17C4E8F2E0F93A4009D76F4 /* GitHubUsersUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		C17C4EA52E0FAFBC009D76F4 /* APIConfig.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APIConfig.stencil; sourceTree = "<group>"; };
+		C17C4EA72E0FAFD1009D76F4 /* APIConfig.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIConfig.generated.swift; sourceTree = "<group>"; };
 		D5AE30B1A987C8164ECA901C /* Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig"; path = "Target Support Files/Pods-GitHubUsers-GitHubUsersUITests/Pods-GitHubUsers-GitHubUsersUITests.release.xcconfig"; sourceTree = "<group>"; };
 		D817333E3DBEFF4D35EC30C4 /* Pods_GitHubUsers_GitHubUsersUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GitHubUsers_GitHubUsersUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1E451BE788102C1C4858679 /* Pods_GitHubUsersTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GitHubUsersTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -164,6 +168,8 @@
 		C17C4E9D2E0FA2FC009D76F4 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				C17C4EA52E0FAFBC009D76F4 /* APIConfig.stencil */,
+				C17C4EA72E0FAFD1009D76F4 /* APIConfig.generated.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -186,6 +192,7 @@
 			buildConfigurationList = C17C4E932E0F93A4009D76F4 /* Build configuration list for PBXNativeTarget "GitHubUsers" */;
 			buildPhases = (
 				7F3A1037E7EA2BCB94E78A35 /* [CP] Check Pods Manifest.lock */,
+				C17C4EA42E0FAF83009D76F4 /* Generate APIConfig.swift */,
 				C17C4E692E0F93A2009D76F4 /* Sources */,
 				C17C4E6A2E0F93A2009D76F4 /* Frameworks */,
 				C17C4E6B2E0F93A2009D76F4 /* Resources */,
@@ -287,6 +294,7 @@
 			files = (
 				C17C4E7A2E0F93A3009D76F4 /* Preview Assets.xcassets in Resources */,
 				C17C4E772E0F93A3009D76F4 /* Assets.xcassets in Resources */,
+				C17C4EA62E0FAFBC009D76F4 /* APIConfig.stencil in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -351,6 +359,25 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		C17C4EA42E0FAF83009D76F4 /* Generate APIConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate APIConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				./GitHubUsers/Helpers/APIConfig.generated.swift,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ -f ./env-vars.sh ]\nthen\nsource ./env-vars.sh\nfi\n\n${PODS_ROOT}/Sourcery/bin/sourcery --templates ./GitHubUsers/Helpers/ --output ./GitHubUsers/Helpers/ --sources ./GitHubUsers/ --args github_access_token=$GITHUB_ACCESS_TOKEN\n";
+		};
 		C8C2ED3CD2501C85B2CC1B9B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -381,6 +408,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C17C4E732E0F93A2009D76F4 /* ContentView.swift in Sources */,
+				C17C4EA82E0FAFD1009D76F4 /* APIConfig.generated.swift in Sources */,
 				C17C4E752E0F93A2009D76F4 /* Item.swift in Sources */,
 				C17C4E712E0F93A2009D76F4 /* GitHubUsersApp.swift in Sources */,
 			);

--- a/GitHubUsers.xcworkspace/contents.xcworkspacedata
+++ b/GitHubUsers.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:GitHubUsers.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/GitHubUsers.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/GitHubUsers.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -2,13 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>SchemeUserState</key>
-	<dict>
-		<key>GitHubUsers.xcscheme_^#shared#^_</key>
-		<dict>
-			<key>orderHint</key>
-			<integer>4</integer>
-		</dict>
-	</dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
 </dict>
 </plist>

--- a/GitHubUsers.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/GitHubUsers.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>SchemeUserState</key>
-	<dict>
-		<key>GitHubUsers.xcscheme_^#shared#^_</key>
-		<dict>
-			<key>orderHint</key>
-			<integer>4</integer>
-		</dict>
-	</dict>
-</dict>
+<dict/>
 </plist>

--- a/GitHubUsers/Helpers/APIConfig.stencil
+++ b/GitHubUsers/Helpers/APIConfig.stencil
@@ -1,0 +1,12 @@
+//
+//  APIConfig.stencil
+//  GitHubUsers
+//
+//  Created by Alwi Alfiansyah Ramdan on 28/06/25.
+//
+
+import Foundation
+
+public struct APIConfig {
+  static let githubAccessToken = "{{ argument.github_access_token }}"
+}

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,21 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '17.0'
+install! 'cocoapods', :deterministic_uuids => false, :warn_for_unused_master_specs_repo => false
+
+target 'GitHubUsers' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  pod 'Sourcery', :subspecs => ['CLI-Only']
+
+  # Pods for GitHubUsers
+  target 'GitHubUsersTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+  target 'GitHubUsersUITests' do
+    # Pods for testing
+  end
+
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Sourcery/CLI-Only (2.2.6)
+
+DEPENDENCIES:
+  - Sourcery/CLI-Only
+
+SPEC REPOS:
+  trunk:
+    - Sourcery
+
+SPEC CHECKSUMS:
+  Sourcery: 4427fd22f0c12bd1ef75dd9045d50e01c17a43e1
+
+PODFILE CHECKSUM: dafb5a9ce7527e9e94eb4c14b53f2db505a5bc93
+
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Create a script to generate `APIConfig` swift file to store GitHub access token to access GitHub API. The secrets themselves are stored in ENV variables. To do this, we use the following approach:

- Create `env-vars.sh` to export `GITHUB_ACCESS_TOKEN` ENV variable value and adding it to gitignore, you need to manually create the file and set the VAR value upon clonning the project
- Use Workspace instead a normal project to be able to use cocoapods
- Add cocoapods to the project to be able to use `Sourcery` binary in `Sourcery` pod to generate the swift file from a template
- Create a swift file template (`GitHubUsers/Helpers/APIConfig.stencil`) as the base to generate the file
- Add new build phase script to generate the APIConfig swift file using Sourcery binary and `GITHUB_ACCESS_TOKEN` ENV variable as the source
- Add `APIConfig.generated.swift` to gitignore. It should be generated by the build phase script, so we do not add it to git