### PR TITLE
Implement infinite scroll to users list and repos list

### DIFF
--- a/GitHubUsers.xcodeproj/project.pbxproj
+++ b/GitHubUsers.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C1727E8D2E10738200F8AFAB /* GitHubUserRepoServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E8C2E10738200F8AFAB /* GitHubUserRepoServices.swift */; };
 		C1727E8F2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E8E2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift */; };
 		C1727E932E11487100F8AFAB /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E922E11487100F8AFAB /* WebView.swift */; };
+		C1727E952E1157CB00F8AFAB /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E942E1157CB00F8AFAB /* View+.swift */; };
 		C17C4E712E0F93A2009D76F4 /* GitHubUsersApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */; };
 		C17C4E732E0F93A2009D76F4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E722E0F93A2009D76F4 /* ContentView.swift */; };
 		C17C4E752E0F93A2009D76F4 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E742E0F93A2009D76F4 /* Item.swift */; };
@@ -86,6 +87,7 @@
 		C1727E8C2E10738200F8AFAB /* GitHubUserRepoServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUserRepoServices.swift; sourceTree = "<group>"; };
 		C1727E8E2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUserRepoListViewItem.swift; sourceTree = "<group>"; };
 		C1727E922E11487100F8AFAB /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		C1727E942E1157CB00F8AFAB /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		C17C4E6D2E0F93A2009D76F4 /* GitHubUsers.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHubUsers.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersApp.swift; sourceTree = "<group>"; };
 		C17C4E722E0F93A2009D76F4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 			children = (
 				C17C4EB12E0FB96D009D76F4 /* Decodable+Decode.swift */,
 				C1727E652E0FE56600F8AFAB /* String+.swift */,
+				C1727E942E1157CB00F8AFAB /* View+.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -606,6 +609,7 @@
 				C1727E802E1006BB00F8AFAB /* GitHubUserListViewItem.swift in Sources */,
 				C1727E6A2E0FE8A300F8AFAB /* APICall.swift in Sources */,
 				C1727E7B2E10043F00F8AFAB /* GitHubUsersAPI.swift in Sources */,
+				C1727E952E1157CB00F8AFAB /* View+.swift in Sources */,
 				C17C4EBC2E0FBA84009D76F4 /* Pagination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitHubUsers/GitHubUserDetails/View/GitHubUserDetailsView.swift
+++ b/GitHubUsers/GitHubUserDetails/View/GitHubUserDetailsView.swift
@@ -9,6 +9,20 @@ import SwiftUI
 
 struct GitHubUserDetailsView: View {
   @ObservedObject var viewModel: GitHubUserDetailsViewModel
+  
+  // Coordinate space for repo list scroll view
+  private let COORDINATE_SPACE: String = "InfiniteReposListScrollContainer"
+  
+  // Bottom offset for loading indicator
+  @State private var bottomOffset: CGFloat?
+  // View height of loading indicator
+  @State private var loadMoreViewHeight: CGFloat?
+  // Lock for loading to prevent multiple calls
+  @State private var loading: Bool = false
+  
+  // Scroll position item id
+  @State var dataID: Int?
+  
   var body: some View {
     VStack {
       GitHubUserInfoView(githubUser: viewModel.githubUser)
@@ -22,7 +36,7 @@ struct GitHubUserDetailsView: View {
           .lineLimit(1)
           .allowsTightening(false)
           .minimumScaleFactor(0.5)
-          .padding(.bottom, 15)
+          .padding(.bottom, 25)
           .padding(.top, 25)
       }
       .frame(minWidth: 0, maxWidth: .infinity)
@@ -37,7 +51,56 @@ struct GitHubUserDetailsView: View {
             }
           }
         }
+        .padding()
+        .scrollTargetLayout()
+        .padding(.bottom, loadMoreViewHeight)
+        .background {
+          // Geometry reader to calculate current scroll view offset
+          // and call onScroll private function
+          GeometryReader { proxy -> Color in
+            onScroll(proxy: proxy)
+            return Color.clear
+          }
+        }
       }
+      .scrollPosition(id: $dataID)
+      .coordinateSpace(name: COORDINATE_SPACE)
+      .overlay(alignment: .bottom) {
+        // Loading indicator
+        // only visible if it's loading and there are something more to be fetched
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle())
+          .scaleEffect(1.5)
+          .padding()
+          .tint(.black)
+          .readGeometry {
+            if loadMoreViewHeight != $0.height {
+              loadMoreViewHeight = $0.height
+            }
+          }
+          .offset(y: bottomOffset ?? 1000)
+          .opacity(loading && viewModel.hasNext ? 1 : 0)
+          
+      }
+      .onChange(of: viewModel.githubRepos.count) { oldValue, newValue in
+        if newValue < oldValue {
+          // if newValue is less than oldValue, the list is empty
+          // we need to refetch the user list
+          Task {
+            await viewModel.fetchInitialGitHubUserRepoList()
+            dataID = viewModel.githubRepos.first?.id
+          }
+        } else if loading {
+          // if newValue is more than oldValue, and it's loading, the list has new items
+          // we need to set the loading to false
+          // add sleep to make sure there is no other process
+          Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            loading = false
+          }
+        }
+      }
+      
       Spacer()
     }
     .navigationTitle("GitLab User Details")
@@ -51,7 +114,43 @@ struct GitHubUserDetailsView: View {
     .onAppear {
       Task {
         await viewModel.fetchUserDetailsInfo()
-        await viewModel.fetchInitialGitHubUserRepoList()
+        
+        // Only reloading github user repo list if current list is empty
+        if viewModel.githubRepos.isEmpty {
+          await viewModel.fetchInitialGitHubUserRepoList()
+          dataID = viewModel.githubRepos.first?.id
+        }
+      }
+    }
+  }
+  
+  // Private function for detecting scroll position for infinite scroll.
+  // Will call async function to fetch more if scroll position is at the bottom
+  private func onScroll(proxy: GeometryProxy) {
+    guard let bound = proxy.bounds(of: .named(COORDINATE_SPACE)) else { return }
+
+    let topOffset = bound.minY
+    let contentHeight = proxy.frame(in: .global).height
+    let bottomOffset = contentHeight - bound.maxY
+    
+    Task { @MainActor in
+      if self.bottomOffset != bottomOffset {
+        self.bottomOffset = bottomOffset
+      }
+      
+      if loading { return }
+      
+      if !viewModel.hasNext {
+        loading = false
+        return
+      }
+      
+      // TODO: fix hard code 0.8
+      if let loadMoreViewHeight {
+        if bottomOffset <= loadMoreViewHeight * 0.8 && topOffset >= 0 {
+          loading = true
+          await viewModel.fetchMoreGitHubUserRepoList()
+        }
       }
     }
   }
@@ -61,10 +160,10 @@ struct GitHubUserDetailsView: View {
   let githubUserAPI = GitHubUsersAPI()
   let githubUser: GitHubUser = GitHubUser(
     id: 4660283,
-    login: "aAlwiAlfiansyah",
+    login: "mojombo",
     name: "Alwi Alfiansyah Ramdan",
     avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
-    reposUrl: "https://api.github.com/users/aAlwiAlfiansyah/repos",
+    reposUrl: "https://api.github.com/users/mojombo/repos",
     type: "User",
     followers: 56,
     following: 12

--- a/GitHubUsers/GitHubUserDetails/View/GitHubUserRepoListViewItem.swift
+++ b/GitHubUsers/GitHubUserDetails/View/GitHubUserRepoListViewItem.swift
@@ -12,63 +12,67 @@ struct GitHubUserRepoListViewItem: View {
   
   var body: some View {
     VStack {
-      if let name = githubRepo.name {
-        Text(name)
-          .font(.system(size: 20, weight: .bold, design: .monospaced))
-          .foregroundStyle(.black)
-          .lineLimit(1)
-          .allowsTightening(true)
-          .minimumScaleFactor(0.5)
-      }
-      
-      HStack(alignment: .bottom) {
-        
-        if let language = githubRepo.language {
-          Text(language)
-            .font(.system(size: 18, weight: .regular, design: .monospaced))
-            .italic()
+      VStack {
+        if let name = githubRepo.name {
+          Text(name)
+            .font(.system(size: 20, weight: .bold, design: .monospaced))
             .foregroundStyle(.black)
             .lineLimit(1)
             .allowsTightening(true)
             .minimumScaleFactor(0.5)
-            
         }
         
-        if let stargazersCount = githubRepo.stargazersCount {
-          Label {
-            Text("(\(stargazersCount))")
-              .font(.system(size: 15, weight: .regular, design: .monospaced))
+        HStack(alignment: .bottom) {
+          
+          if let language = githubRepo.language {
+            Text(language)
+              .font(.system(size: 18, weight: .regular, design: .monospaced))
+              .italic()
               .foregroundStyle(.black)
               .lineLimit(1)
               .allowsTightening(true)
               .minimumScaleFactor(0.5)
-          } icon: {
-            Image(systemName: "star.fill")
+              
+          }
+          
+          if let stargazersCount = githubRepo.stargazersCount {
+            Label {
+              Text("(\(stargazersCount))")
+                .font(.system(size: 15, weight: .regular, design: .monospaced))
+                .foregroundStyle(.black)
+                .lineLimit(1)
+                .allowsTightening(true)
+                .minimumScaleFactor(0.5)
+            } icon: {
+              Image(systemName: "star.fill")
+                .foregroundColor(.black.opacity(0.5))
+            }
           }
         }
-      }
-      .padding(.top, 5)
-      .padding(.bottom, 15)
-      
-      if let description = githubRepo.description {
-        Text(description)
-          .font(.system(size: 15, weight: .regular, design: .monospaced))
-          .italic()
-          .foregroundStyle(.black)
-          .lineLimit(3)
-          .allowsTightening(false)
-          .minimumScaleFactor(0.8)
-          .padding(.bottom, 15)
-          .padding(.top, 5)
+        .padding(.top, 5)
+        .padding(.bottom, 15)
+        
+        if let description = githubRepo.description {
+          Text(description)
+            .font(.system(size: 15, weight: .regular, design: .monospaced))
+            .italic()
+            .foregroundStyle(.black)
+            .lineLimit(3)
+            .allowsTightening(false)
+            .minimumScaleFactor(0.8)
+            .padding(.bottom, 15)
+            .padding(.top, 5)
+        }
       }
       
       Line()
         .stroke(lineWidth: /*@START_MENU_TOKEN@*/1.0/*@END_MENU_TOKEN@*/)
         .frame(height: 1)
-//        .padding(.vertical)
-      
+        .foregroundColor(.black.opacity(0.8))
     }
     .padding()
+    .background(Color.gray.opacity(0.2))
+    .clipShape(.rect(cornerRadius: 25))
   }
 }
 

--- a/GitHubUsers/GitHubUserList/View/GitHubUserListView.swift
+++ b/GitHubUsers/GitHubUserList/View/GitHubUserListView.swift
@@ -11,16 +11,21 @@ struct GitHubUserListView: View {
   @ObservedObject var viewModel: GitHubUserListViewModel
   
   private static let initialColumns = 3
+  
+  // Coordinate space for list scroll view
   private let COORDINATE_SPACE: String = "InfiniteScrollContainer"
   
   @State private var gridColumns = Array(repeating: GridItem(.flexible()), count: initialColumns)
   @State private var numColumns = initialColumns
   
+  // Bottom offset for loading indicator
   @State private var bottomOffset: CGFloat?
+  // View height of loading indicator
   @State private var loadMoreViewHeight: CGFloat?
   // Lock for loading to prevent multiple calls
   @State private var loading: Bool = false
   
+  // Scroll position item id
   @State var dataID: Int?
 
   
@@ -43,11 +48,54 @@ struct GitHubUserListView: View {
         .padding()
         .scrollTargetLayout()
         .padding(.bottom, loadMoreViewHeight)
+        .background {
+          // Geometry reader to calculate current scroll view offset
+          // and call onScroll private function
+          GeometryReader { proxy -> Color in
+            onScroll(proxy: proxy)
+            return Color.clear
+          }
+        }
       }
       .scrollPosition(id: $dataID)
       .coordinateSpace(name: COORDINATE_SPACE)
       .navigationTitle("GitLab User List")
       .navigationBarTitleDisplayMode(.inline)
+      .overlay(alignment: .bottom) {
+        // Loading indicator
+        // only visible if it's loading and there are something more to be fetched
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle())
+          .scaleEffect(1.5)
+          .padding()
+          .tint(.black)
+          .readGeometry {
+            if loadMoreViewHeight != $0.height {
+              loadMoreViewHeight = $0.height
+            }
+          }
+          .offset(y: bottomOffset ?? 1000)
+          .opacity(loading && viewModel.hasNext ? 1 : 0)
+          
+      }
+      .onChange(of: viewModel.githubUsers.count) { oldValue, newValue in
+        if newValue < oldValue {
+          // if newValue is less than oldValue, the list is empty
+          // we need to refetch the user list
+          Task {
+            await viewModel.fetchInitialGitHubUserList()
+            dataID = viewModel.githubUsers.first?.id
+          }
+        } else if loading {
+          // if newValue is more than oldValue, and it's loading, the list has new items
+          // we need to set the loading to false
+          // add sleep to make sure there is no other process
+          Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            loading = false
+          }
+        }
+      }
       .navigationDestination(for: GitHubUser.self) { [weak viewModel] user in
         
         if let gitHubUsersAPI = viewModel?.gitHubUsersAPI {
@@ -59,7 +107,37 @@ struct GitHubUserListView: View {
     }
     .onAppear {
       Task {
-        await viewModel.fetchInitialGitHubUserList()
+        // Only reloading github user list if current list is empty
+        if viewModel.githubUsers.isEmpty {
+          await viewModel.fetchInitialGitHubUserList()
+          dataID = viewModel.githubUsers.first?.id
+        }
+      }
+    }
+  }
+  
+  // Private function for detecting scroll position for infinite scroll.
+  // Will call async function to fetch more if scroll position is at the bottom
+  private func onScroll(proxy: GeometryProxy) {
+    guard let bound = proxy.bounds(of: .named(COORDINATE_SPACE)) else { return }
+
+    let topOffset = bound.minY
+    let contentHeight = proxy.frame(in: .global).height
+    let bottomOffset = contentHeight - bound.maxY
+    
+    Task { @MainActor in
+      if self.bottomOffset != bottomOffset {
+        self.bottomOffset = bottomOffset
+      }
+      
+      if loading { return }
+      
+      // TODO: fix hard code 0.8
+      if let loadMoreViewHeight {
+        if bottomOffset <= loadMoreViewHeight * 0.8 && topOffset >= 0 {
+          loading = true
+          await viewModel.fetchMoreGitHubUserList()
+        }
       }
     }
   }

--- a/GitHubUsers/Network/Pagination.swift
+++ b/GitHubUsers/Network/Pagination.swift
@@ -58,17 +58,29 @@ public struct PagedObject<T>: Codable, Sendable where T: Sendable {
   
   /// True if there are additional results that can be retrieved
   public var hasNext: Bool {
-    return next != nil
+    guard let nextValue = next else {
+      return false
+    }
+    
+    return !nextValue.isEmpty
   }
   
   /// True if there are previous results that can be retrieved
   public var hasPrevious: Bool {
-    return previous != nil
+    guard let prevValue = previous else {
+      return false
+    }
+    
+    return !prevValue.isEmpty
   }
   
   /// True if there are results that can be retrieved in the last page
   public var hasLast: Bool {
-    return last != nil
+    guard let lastValue = last else {
+      return false
+    }
+    
+    return !lastValue.isEmpty
   }
   
   

--- a/GitHubUsers/Utilities/View+.swift
+++ b/GitHubUsers/Utilities/View+.swift
@@ -1,0 +1,41 @@
+//
+//  View+Extensions.swift
+//  GitHubUsers
+//
+//  Created by Alwi Alfiansyah Ramdan on 29/06/25.
+//
+
+import SwiftUI
+
+@available(iOS 14, macOS 11, *)
+public extension View {
+  /// Read the geometry of the view.
+  func readGeometry(onChange: @escaping (CGSize) -> ()) -> some View {
+    modifier(HuggingGeometryModifier {
+      onChange($0)
+    })
+  }
+}
+
+@available(iOS 14, macOS 11, *)
+internal struct HuggingGeometryModifier: ViewModifier {
+
+  let onChange: (CGSize) -> ()
+    
+  func body(content: Content) -> some View {
+    content
+      .background(
+        GeometryReader { proxy in
+          Color.clear.preference(key: SizeKey.self, value: proxy.size)
+        }
+      )
+      .onPreferenceChange(SizeKey.self) {
+        onChange($0)
+      }
+  }
+    
+  private struct SizeKey: PreferenceKey {
+    static var defaultValue: CGSize { CGSize() }
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
+  }
+}


### PR DESCRIPTION
Implement infinite scroll feature to fetch more records from API for user list scroll view in GitHubUserListView and user repo list scroll view in GitHubUserDetailsView.

<h1>Additions:</h1>

Utilities:
- `Utilities/View+.swift`: View extensions to read geometry changes

<h1>Changes:</h1>

Network:
- `Network/Pagination.swift`: Fix checker for next, prev and last in pagination

ViewModel:
- `GitHubUserList/ViewModel/GitHubUserListViewModel.swift`: Add new function to fetch more data for GitHub user list
- `GitHubUserDetails/ViewModel/GitHubUserDetailsViewModel.swift`: Add new function to fetch more data for GitHub user repository list

View:
- `GitHubUserList/View/GitHubUserListView.swift`: Implement infinite scroll for User List Scrollview
- `GitHubUserDetails/View/GitHubUserDetailsView.swift`: Implement infinite scroll for User Repository List Scrollview
- `GitHubUserDetails/View/GitHubUserRepoListViewItem.swift`: Update User Repository List Item View

