### PR TITLE
Prepare unit testing

### DIFF
--- a/GitHubUsers.xcodeproj/project.pbxproj
+++ b/GitHubUsers.xcodeproj/project.pbxproj
@@ -26,6 +26,12 @@
 		C1727E8F2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E8E2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift */; };
 		C1727E932E11487100F8AFAB /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E922E11487100F8AFAB /* WebView.swift */; };
 		C1727E952E1157CB00F8AFAB /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E942E1157CB00F8AFAB /* View+.swift */; };
+		C1727E982E11AA4800F8AFAB /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = C1727E972E11AA4800F8AFAB /* Quick */; };
+		C1727E9B2E11AA6B00F8AFAB /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = C1727E9A2E11AA6B00F8AFAB /* Nimble */; };
+		C1727E9E2E11AAC400F8AFAB /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727E9D2E11AAC400F8AFAB /* StringExtensionsTests.swift */; };
+		C1727EA12E11B15200F8AFAB /* GitHubUserListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727EA02E11B15200F8AFAB /* GitHubUserListViewModelTests.swift */; };
+		C1727EA42E11B43700F8AFAB /* MockedServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727EA32E11B43700F8AFAB /* MockedServices.swift */; };
+		C1727EA62E11CAC700F8AFAB /* GitHubUserDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1727EA52E11CAC700F8AFAB /* GitHubUserDetailsViewModelTests.swift */; };
 		C17C4E712E0F93A2009D76F4 /* GitHubUsersApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */; };
 		C17C4E732E0F93A2009D76F4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E722E0F93A2009D76F4 /* ContentView.swift */; };
 		C17C4E752E0F93A2009D76F4 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17C4E742E0F93A2009D76F4 /* Item.swift */; };
@@ -88,6 +94,10 @@
 		C1727E8E2E10784500F8AFAB /* GitHubUserRepoListViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUserRepoListViewItem.swift; sourceTree = "<group>"; };
 		C1727E922E11487100F8AFAB /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		C1727E942E1157CB00F8AFAB /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		C1727E9D2E11AAC400F8AFAB /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
+		C1727EA02E11B15200F8AFAB /* GitHubUserListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUserListViewModelTests.swift; sourceTree = "<group>"; };
+		C1727EA32E11B43700F8AFAB /* MockedServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedServices.swift; sourceTree = "<group>"; };
+		C1727EA52E11CAC700F8AFAB /* GitHubUserDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUserDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		C17C4E6D2E0F93A2009D76F4 /* GitHubUsers.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHubUsers.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C17C4E702E0F93A2009D76F4 /* GitHubUsersApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersApp.swift; sourceTree = "<group>"; };
 		C17C4E722E0F93A2009D76F4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -129,6 +139,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1727E9B2E11AA6B00F8AFAB /* Nimble in Frameworks */,
+				C1727E982E11AA4800F8AFAB /* Quick in Frameworks */,
 				09C3A65388E1D7F3ABC1B04A /* Pods_GitHubUsersTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -245,6 +257,31 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		C1727E9C2E11AA9F00F8AFAB /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				C1727E9D2E11AAC400F8AFAB /* StringExtensionsTests.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		C1727E9F2E11AEC300F8AFAB /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C1727EA02E11B15200F8AFAB /* GitHubUserListViewModelTests.swift */,
+				C1727EA52E11CAC700F8AFAB /* GitHubUserDetailsViewModelTests.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C1727EA22E11B42000F8AFAB /* MockedServices */ = {
+			isa = PBXGroup;
+			children = (
+				C1727EA32E11B43700F8AFAB /* MockedServices.swift */,
+			);
+			path = MockedServices;
+			sourceTree = "<group>";
+		};
 		C17C4E642E0F93A2009D76F4 = {
 			isa = PBXGroup;
 			children = (
@@ -298,6 +335,9 @@
 		C17C4E822E0F93A4009D76F4 /* GitHubUsersTests */ = {
 			isa = PBXGroup;
 			children = (
+				C1727EA22E11B42000F8AFAB /* MockedServices */,
+				C1727E9F2E11AEC300F8AFAB /* ViewModel */,
+				C1727E9C2E11AA9F00F8AFAB /* Utilities */,
 				C17C4E832E0F93A4009D76F4 /* GitHubUsersTests.swift */,
 			);
 			path = GitHubUsersTests;
@@ -395,6 +435,10 @@
 				C17C4E812E0F93A4009D76F4 /* PBXTargetDependency */,
 			);
 			name = GitHubUsersTests;
+			packageProductDependencies = (
+				C1727E972E11AA4800F8AFAB /* Quick */,
+				C1727E9A2E11AA6B00F8AFAB /* Nimble */,
+			);
 			productName = GitHubUsersTests;
 			productReference = C17C4E7F2E0F93A4009D76F4 /* GitHubUsersTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -450,6 +494,10 @@
 				Base,
 			);
 			mainGroup = C17C4E642E0F93A2009D76F4;
+			packageReferences = (
+				C1727E962E11AA4800F8AFAB /* XCRemoteSwiftPackageReference "Quick" */,
+				C1727E992E11AA6B00F8AFAB /* XCRemoteSwiftPackageReference "Nimble" */,
+			);
 			productRefGroup = C17C4E6E2E0F93A2009D76F4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -618,6 +666,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1727EA62E11CAC700F8AFAB /* GitHubUserDetailsViewModelTests.swift in Sources */,
+				C1727EA12E11B15200F8AFAB /* GitHubUserListViewModelTests.swift in Sources */,
+				C1727E9E2E11AAC400F8AFAB /* StringExtensionsTests.swift in Sources */,
+				C1727EA42E11B43700F8AFAB /* MockedServices.swift in Sources */,
 				C17C4E842E0F93A4009D76F4 /* GitHubUsersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -942,6 +994,38 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C1727E962E11AA4800F8AFAB /* XCRemoteSwiftPackageReference "Quick" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Quick.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 7.0.2;
+			};
+		};
+		C1727E992E11AA6B00F8AFAB /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 12.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C1727E972E11AA4800F8AFAB /* Quick */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C1727E962E11AA4800F8AFAB /* XCRemoteSwiftPackageReference "Quick" */;
+			productName = Quick;
+		};
+		C1727E9A2E11AA6B00F8AFAB /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C1727E992E11AA6B00F8AFAB /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C17C4E652E0F93A2009D76F4 /* Project object */;
 }

--- a/GitHubUsers.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitHubUsers.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "edaedc1ec86f14ac6e2ca495b94f0ff7150d98d0",
+        "version" : "12.3.0"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "91132c0fe9a98e76f3d7381a608685aa41770706",
+        "version" : "7.0.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/GitHubUsers/Models/GitHubUser.swift
+++ b/GitHubUsers/Models/GitHubUser.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - GitHub User
 
-public struct GitHubUser: Codable, Sendable, Hashable {
+public struct GitHubUser: Codable, Sendable, Hashable, Equatable {
   
   /// The id for this GitHub User resource
   public let id: Int?

--- a/GitHubUsers/Network/Pagination.swift
+++ b/GitHubUsers/Network/Pagination.swift
@@ -119,7 +119,7 @@ public struct PagedObject<T>: Codable, Sendable where T: Sendable {
     switch paginationState {
     case .initial(let newLimit):
       limit = newLimit
-    case .continuing(let pagedObject, let relationship):
+    case .continuing(let pagedObject, _):
       limit = pagedObject.limit
     }
     
@@ -131,7 +131,7 @@ public struct PagedObject<T>: Codable, Sendable where T: Sendable {
   public func getPageLink(for relationship: PaginationRelationship) -> String? {
     switch relationship {
     case .first:
-      guard var url = self.first, url.count > 0 else {
+      guard let url = self.first, url.count > 0 else {
         return nil
       }
       
@@ -147,7 +147,7 @@ public struct PagedObject<T>: Codable, Sendable where T: Sendable {
   
   /// Helper function. Returns the url string if it exists, nil otherwise or the url is empty
   private func getLink(from urlString: String?) -> String? {
-    guard var url = urlString, url.count > 0 else {
+    guard let url = urlString, url.count > 0 else {
       return nil
     }
     

--- a/GitHubUsers/Services/GitHubUserRepoServices.swift
+++ b/GitHubUsers/Services/GitHubUserRepoServices.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol GHUGitHubUserRepoService: HTTPWebService, Sendable {
+public protocol GHUGitHubUserRepoService: HTTPWebService, Sendable {
   func fetchUserRepoList(_ username: String, paginationState: PaginationState<GitHubRepo>) async throws -> PagedObject<GitHubRepo>
 }
 
@@ -29,6 +29,11 @@ public struct GitHubUserRepoService: GHUGitHubUserRepoService, Sendable {
   public var session: URLSession
   
   public var baseURL: String = "https://api.github.com"
+  
+  /// Initializer
+  public init(session: URLSession) {
+    self.session = session
+  }
   
   
   /**

--- a/GitHubUsers/Services/GitHubUserServices.swift
+++ b/GitHubUsers/Services/GitHubUserServices.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol GHUGitHubUserService: HTTPWebService, Sendable {
+public protocol GHUGitHubUserService: HTTPWebService, Sendable {
   func fetchUserList(paginationState: PaginationState<GitHubUser>) async throws -> PagedObject<GitHubUser>
   func fetchUser(_ username: String) async throws -> GitHubUser
 }
@@ -33,6 +33,10 @@ public struct GitHubUserService: GHUGitHubUserService, Sendable {
   
   public var baseURL: String = "https://api.github.com"
   
+  /// Initializer
+  public init(session: URLSession) {
+    self.session = session
+  }
   
   /**
    Fetch GitHub User list

--- a/GitHubUsers/Services/GitHubUsersAPI.swift
+++ b/GitHubUsers/Services/GitHubUsersAPI.swift
@@ -8,15 +8,18 @@
 import Foundation
 
 public final class GitHubUsersAPI: Sendable {
-    public let session: URLSession
-    
-    public init(session: URLSession = URLSession.shared) {
-        self.session = session
-        
-        githubUserService = GitHubUserService(session: session)
-        githubUserRepoService = GitHubUserRepoService(session: session)
+  public let session: URLSession
+  
+  public init(
+    session: URLSession = URLSession.shared,
+    githubUserService: GHUGitHubUserService = GitHubUserService(session: URLSession.shared),
+    githubuserRepoService: GHUGitHubUserRepoService = GitHubUserRepoService(session: URLSession.shared)) {
+      self.session = session
+      
+      self.githubUserService = githubUserService
+      self.githubUserRepoService = githubuserRepoService
     }
-    
-    public let githubUserService: GitHubUserService
-    public let githubUserRepoService: GitHubUserRepoService
+  
+  public let githubUserService: GHUGitHubUserService
+  public let githubUserRepoService: GHUGitHubUserRepoService
 }

--- a/GitHubUsersTests/MockedServices/MockedServices.swift
+++ b/GitHubUsersTests/MockedServices/MockedServices.swift
@@ -1,0 +1,143 @@
+//
+//  MockedServices.swift
+//  GitHubUsersTests
+//
+//  Created by Alwi Alfiansyah Ramdan on 30/06/25.
+//
+
+import Foundation
+@testable import GitHubUsers
+
+class MockURLProtocol: URLProtocol {
+  static var mockResponses: [URL: (data: Data?, response: URLResponse?, error: Error?)] = [:]
+  
+  static func reset() {
+    mockResponses = [:]
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    return true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    return request
+  }
+  
+  override func startLoading() {
+    if let url = request.url,
+       let mockResponse = MockURLProtocol.mockResponses[url] {
+      if let responseError = mockResponse.error {
+        client?.urlProtocol(self, didFailWithError: responseError)
+        client?.urlProtocolDidFinishLoading(self)
+        return
+      }
+      
+      if let responseData = mockResponse.data {
+        client?.urlProtocol(self, didLoad: responseData)
+      }
+      
+      if let response = mockResponse.response {
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      }
+      
+      client?.urlProtocolDidFinishLoading(self)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+struct MockedGitHubUserService: GHUGitHubUserService {
+  var session: URLSession {
+    if let mockSession = mockUrlSession {
+      return mockSession
+    }
+    
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+  var baseURL: String {
+    if let url = mockBaseURL {
+      return url
+    }
+    
+    return ""
+  }
+  
+  var mockGitHubUser: GitHubUser?
+  var mockPagedObject: PagedObject<GitHubUser>?
+  var mockError: Error?
+  var mockUrlSession: URLSession?
+  var mockBaseURL: String?
+  
+  func fetchUserList(paginationState: PaginationState<GitHubUser>) async throws -> PagedObject<GitHubUser> {
+    if let pagedObject = mockPagedObject {
+      return pagedObject
+    }
+    
+    if let error = mockError {
+      throw error
+    }
+    
+    return PagedObject(from: nil, with: .initial(pageLimit: 1), currentUrl: "", results: [])
+  }
+  
+  func fetchUser(_ username: String) async throws -> GitHubUser {
+    if let user = mockGitHubUser {
+      return user
+    }
+    
+    if let error = mockError {
+      throw error
+    }
+
+    return GitHubUser(
+      id: nil,
+      login: nil,
+      name: nil,
+      avatarUrl: nil,
+      reposUrl: nil,
+      type: nil,
+      followers: nil,
+      following: nil)
+  }
+  
+}
+
+struct MockedGitHubUserRepoService: GHUGitHubUserRepoService {
+  var session: URLSession {
+    if let mockSession = mockUrlSession {
+      return mockSession
+    }
+    
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+  var baseURL: String {
+    if let url = mockBaseURL {
+      return url
+    }
+    
+    return ""
+  }
+  
+  var mockPagedObject: PagedObject<GitHubRepo>?
+  var mockError: Error?
+  var mockUrlSession: URLSession?
+  var mockBaseURL: String?
+  
+  func fetchUserRepoList(_ username: String, paginationState: PaginationState<GitHubRepo>) async throws -> PagedObject<GitHubRepo> {
+    
+    if let pagedObject = mockPagedObject {
+      return pagedObject
+    }
+    
+    if let error = mockError {
+      throw error
+    }
+    
+    return PagedObject(from: nil, with: .initial(pageLimit: 1), currentUrl: "", results: [])
+  }
+}

--- a/GitHubUsersTests/Utilities/StringExtensionsTests.swift
+++ b/GitHubUsersTests/Utilities/StringExtensionsTests.swift
@@ -1,0 +1,29 @@
+//
+//  StringExtensionsTests.swift
+//  GitHubUsersTests
+//
+//  Created by Alwi Alfiansyah Ramdan on 30/06/25.
+//
+
+import XCTest
+
+import Quick
+import Nimble
+@testable import GitHubUsers
+
+final class StringExtensionsTests: QuickSpec {
+
+  override class func spec(){
+    describe("String Class") {
+      describe("deletingPrefix") {
+        it("should return the correct value") {
+          
+          expect("".deletingPrefix("dogI")).to(equal(""))
+          expect("dogImage.dogBreed".deletingPrefix("dogI")).to(equal("mage.dogBreed"))
+          expect("dogImage.dogBreed".deletingPrefix("mamamia")).to(equal("dogImage.dogBreed"))
+        }
+      }
+    }
+  }
+
+}

--- a/GitHubUsersTests/ViewModel/GitHubUserDetailsViewModelTests.swift
+++ b/GitHubUsersTests/ViewModel/GitHubUserDetailsViewModelTests.swift
@@ -1,0 +1,313 @@
+//
+//  GitHubUserDetailsViewModelTests.swift
+//  GitHubUsersTests
+//
+//  Created by Alwi Alfiansyah Ramdan on 30/06/25.
+//
+
+import XCTest
+import Quick
+import Nimble
+@testable import GitHubUsers
+
+final class GitHubUserDetailsViewModelTests: AsyncSpec {
+  override class func spec(){
+    describe("GitHubUserDetailsViewModel") {
+      var gitHubUsersAPI: GitHubUsersAPI!
+      var githubUserService: MockedGitHubUserService!
+      var githubUserRepoService: MockedGitHubUserRepoService!
+      var sut: GitHubUserDetailsViewModel!
+      var githubUser: GitHubUser!
+      
+      beforeEach {
+        githubUserService = MockedGitHubUserService()
+        githubUserRepoService = MockedGitHubUserRepoService()
+        gitHubUsersAPI = GitHubUsersAPI(
+          githubUserService: githubUserService,
+          githubuserRepoService: githubUserRepoService)
+        
+        githubUser = GitHubUser(
+          id: 23,
+          login: "adul",
+          name: nil,
+          avatarUrl: "some avatar",
+          reposUrl: nil,
+          type: nil,
+          followers: nil,
+          following: nil)
+        
+        sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+      }
+      
+      describe("init") {
+        it("should setup githubRepos array") {
+          expect(sut.githubRepos).to(equal([]))
+        }
+        
+        it("should setup repoMap dictionary") {
+          expect(sut.repoMap).to(equal([:]))
+        }
+        
+        it("should setup hasNext") {
+          expect(sut.hasNext).to(beFalse())
+        }
+      }
+      
+      describe("fetchUserDetailsInfo") {
+        var data: GitHubUser!
+        var err: Error!
+        
+        beforeEach {
+          data = GitHubUser(
+            id: 23,
+            login: "adul",
+            name: "adul adul",
+            avatarUrl: "some avatar",
+            reposUrl: "some repo url",
+            type: "User",
+            followers: 20,
+            following: 3)
+          
+          err = HTTPError.unexpectedResponse
+        }
+        
+        it("should set githubUser value to the new one") {
+          githubUserService = MockedGitHubUserService(mockGitHubUser: data)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          
+          await sut.fetchUserDetailsInfo()
+          await expect(sut.githubUser.id).toEventually(equal(data.id))
+          await expect(sut.githubUser.login).toEventually(equal(data.login))
+          await expect(sut.githubUser.name).toEventually(equal(data.name))
+          await expect(sut.githubUser.avatarUrl).toEventually(equal(data.avatarUrl))
+          await expect(sut.githubUser.reposUrl).toEventually(equal(data.reposUrl))
+          await expect(sut.githubUser.type).toEventually(equal(data.type))
+          await expect(sut.githubUser.followers).toEventually(equal(data.followers))
+          await expect(sut.githubUser.following).toEventually(equal(data.following))
+          
+        }
+        
+        it("should not set githubUser value to the new one  as the fetch failed") {
+          githubUserService = MockedGitHubUserService(mockError: err)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          
+          await sut.fetchUserDetailsInfo()
+          await expect(sut.githubUser.id).toEventually(equal(data.id))
+          await expect(sut.githubUser.login).toEventually(equal(data.login))
+          await expect(sut.githubUser.name).toEventually(beNil())
+          await expect(sut.githubUser.avatarUrl).toEventually(equal(data.avatarUrl))
+          await expect(sut.githubUser.reposUrl).toEventually(beNil())
+          await expect(sut.githubUser.type).toEventually(beNil())
+          await expect(sut.githubUser.followers).toEventually(beNil())
+          await expect(sut.githubUser.following).toEventually(beNil())
+          
+        }
+      }
+      
+      describe("fetchInitialGitHubUserRepoList") {
+        var data: [GitHubRepo]!
+        var headerLink: HTTPResponseHeaderLink!
+        var pagedObject: PagedObject<GitHubRepo>!
+        var err: Error!
+        
+        var data1: GitHubRepo!
+        var data2: GitHubRepo!
+        var data3: GitHubRepo!
+        var data4: GitHubRepo!
+        
+        beforeEach {
+          headerLink = HTTPResponseHeaderLink(rawValue: """
+            <https://api.github.com/>; rel="next", <https://api.github.com/>; rel="first"
+          """)
+          
+          data1 = GitHubRepo(
+            id: 1,
+            name: "repo 1",
+            description: "description for repo 1",
+            fork: false,
+            htmlUrl: "some html url 1",
+            language: "Javascript",
+            stargazersCount: 12)
+          
+          data2 = GitHubRepo(
+            id: 2,
+            name: "repo 2",
+            description: "description for repo 2",
+            fork: true,
+            htmlUrl: "some html url 2",
+            language: "Java",
+            stargazersCount: 21)
+          
+          
+          data3 = GitHubRepo(
+            id: 3,
+            name: "repo 3",
+            description: "description for repo 3",
+            fork: false,
+            htmlUrl: "some html url 3",
+            language: "Ruby",
+            stargazersCount: 430)
+          
+          
+          data4 = GitHubRepo(
+            id: 4,
+            name: "repo 4",
+            description: "description for repo 4",
+            fork: false,
+            htmlUrl: "some html url 4",
+            language: "Swift",
+            stargazersCount: 1253)
+          
+          data = [data1,data2,data3,data4]
+          
+          pagedObject = PagedObject(from: headerLink, with: .initial(pageLimit: 1), currentUrl: "", results: data)
+          
+          err = HTTPError.unexpectedResponse
+        }
+        
+        it("should set githubRepo array") {
+          githubUserRepoService = MockedGitHubUserRepoService(mockPagedObject: pagedObject)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          
+          let expected = [data1, data3, data4]
+          
+          await sut.fetchInitialGitHubUserRepoList()
+          await expect(sut.githubRepos).toEventually(equal(expected))
+        }
+        
+        it("should not set githubRepo array as fetching failed") {
+          githubUserRepoService = MockedGitHubUserRepoService(mockError: err)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          
+          await sut.fetchInitialGitHubUserRepoList()
+          await expect(sut.githubRepos).toEventually(equal([]))
+        }
+      }
+      
+      describe("fetchMoreGitHubUserRepoList") {
+        var data: [GitHubRepo]!
+        var initialRepos: [GitHubRepo]!
+        var headerLink: HTTPResponseHeaderLink!
+        var pagedObject: PagedObject<GitHubRepo>!
+        var err: Error!
+        
+        var data1: GitHubRepo!
+        var data2: GitHubRepo!
+        var data3: GitHubRepo!
+        var data4: GitHubRepo!
+        var data5: GitHubRepo!
+        
+        beforeEach {
+          headerLink = HTTPResponseHeaderLink(rawValue: """
+            <https://api.github.com/>; rel="next", <https://api.github.com/>; rel="first"
+          """)
+          
+          data1 = GitHubRepo(
+            id: 1,
+            name: "repo 1",
+            description: "description for repo 1",
+            fork: false,
+            htmlUrl: "some html url 1",
+            language: "Javascript",
+            stargazersCount: 12)
+          
+          data2 = GitHubRepo(
+            id: 2,
+            name: "repo 2",
+            description: "description for repo 2",
+            fork: false,
+            htmlUrl: "some html url 2",
+            language: "Java",
+            stargazersCount: 21)
+          
+          
+          data3 = GitHubRepo(
+            id: 3,
+            name: "repo 3",
+            description: "description for repo 3",
+            fork: false,
+            htmlUrl: "some html url 3",
+            language: "Ruby",
+            stargazersCount: 430)
+          
+          
+          data4 = GitHubRepo(
+            id: 4,
+            name: "repo 4",
+            description: "description for repo 4",
+            fork: true,
+            htmlUrl: "some html url 4",
+            language: "Swift",
+            stargazersCount: 1253)
+          
+          data5 = GitHubRepo(
+            id: 5,
+            name: "repo 5",
+            description: "description for repo 5",
+            fork: false,
+            htmlUrl: "some html url 5",
+            language: "Kotlin",
+            stargazersCount: 5422)
+          
+          initialRepos = [data1,data2]
+          data = [data3,data4,data5]
+          
+          pagedObject = PagedObject(from: headerLink, with: .initial(pageLimit: 1), currentUrl: "", results: data)
+          
+          err = HTTPError.unexpectedResponse
+        }
+        
+        it("should update githubRepo array") {
+          githubUserRepoService = MockedGitHubUserRepoService(mockPagedObject: pagedObject)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          sut.githubRepos = initialRepos
+          sut.repoMap = [
+            initialRepos[0].id!: initialRepos[0],
+            initialRepos[1].id!: initialRepos[1],
+          ]
+          sut.pagedObject = pagedObject
+          
+          var expected: [GitHubRepo] = initialRepos
+          expected.append(data3)
+          expected.append(data5)
+          
+          await sut.fetchMoreGitHubUserRepoList()
+          await expect(sut.githubRepos).toEventually(equal(expected))
+        }
+        
+        it("should not update githubRepo array as the fetch failed") {
+          githubUserRepoService = MockedGitHubUserRepoService(mockError: err)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserDetailsViewModel(githubUser: githubUser, gitHubUsersAPI: gitHubUsersAPI)
+          sut.githubRepos = initialRepos
+          sut.repoMap = [
+            initialRepos[0].id!: initialRepos[0],
+            initialRepos[1].id!: initialRepos[1],
+          ]
+          sut.pagedObject = pagedObject
+          
+          await sut.fetchMoreGitHubUserRepoList()
+          await expect(sut.githubRepos).toEventually(equal(initialRepos))
+        }
+      }
+    }
+  }
+  
+}

--- a/GitHubUsersTests/ViewModel/GitHubUserListViewModelTests.swift
+++ b/GitHubUsersTests/ViewModel/GitHubUserListViewModelTests.swift
@@ -1,0 +1,203 @@
+//
+//  GitHubUserListViewModelTests.swift
+//  GitHubUsersTests
+//
+//  Created by Alwi Alfiansyah Ramdan on 30/06/25.
+//
+
+import XCTest
+import Quick
+import Nimble
+@testable import GitHubUsers
+
+final class GitHubUserListViewModelTests: AsyncSpec {
+  
+  override class func spec(){
+    describe("GitHubUserListViewModel") {
+      var gitHubUsersAPI: GitHubUsersAPI!
+      var githubUserService: MockedGitHubUserService!
+      var githubUserRepoService: MockedGitHubUserRepoService!
+      var sut: GitHubUserListViewModel!
+      
+      beforeEach {
+        githubUserService = MockedGitHubUserService()
+        githubUserRepoService = MockedGitHubUserRepoService()
+        gitHubUsersAPI = GitHubUsersAPI(
+          githubUserService: githubUserService,
+          githubuserRepoService: githubUserRepoService)
+        
+        sut = GitHubUserListViewModel(githubUsersAPI: gitHubUsersAPI)
+      }
+      
+      describe("init") {
+        it("should setup githubUsers array") {
+          expect(sut.githubUsers).to(equal([]))
+        }
+        
+        it("should setup userMap dictionary") {
+          expect(sut.userMap).to(equal([:]))
+        }
+        
+        it("should setup hasNext") {
+          expect(sut.hasNext).to(beFalse())
+        }
+      }
+      
+      describe("fetchInitialGitHubUserList") {
+        var data: [GitHubUser]!
+        var headerLink: HTTPResponseHeaderLink!
+        var pagedObject: PagedObject<GitHubUser>!
+        var err: Error!
+        
+        beforeEach {
+          headerLink = HTTPResponseHeaderLink(rawValue: """
+            <https://api.github.com/>; rel="next", <https://api.github.com/>; rel="first"
+          """)
+          data = [
+            GitHubUser(
+              id: 1,
+              login: "adul",
+              name: "adul adul",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+            GitHubUser(
+              id: 2,
+              login: "mike",
+              name: "mike shinoda",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+          ]
+          
+          pagedObject = PagedObject(from: headerLink, with: .initial(pageLimit: 1), currentUrl: "", results: data)
+          
+          err = HTTPError.unexpectedResponse
+          
+        }
+        
+        it("should set githubUsers array") {
+          githubUserService = MockedGitHubUserService(mockPagedObject: pagedObject)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserListViewModel(githubUsersAPI: gitHubUsersAPI)
+          
+          await sut.fetchInitialGitHubUserList()
+          await expect(sut.githubUsers).toEventually(equal(data))
+        }
+        
+        it("should set empty githubUsers array as the fetch failed") {
+          githubUserService = MockedGitHubUserService(mockError: err)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserListViewModel(githubUsersAPI: gitHubUsersAPI)
+          
+          await sut.fetchInitialGitHubUserList()
+          await expect(sut.githubUsers).toEventually(equal([]))
+        }
+      }
+      
+      describe("fetchMoreGitHubUserList") {
+        var data: [GitHubUser]!
+        var initialData: [GitHubUser]!
+        var headerLink: HTTPResponseHeaderLink!
+        var pagedObject: PagedObject<GitHubUser>!
+        var err: Error!
+        
+        beforeEach {
+          headerLink = HTTPResponseHeaderLink(rawValue: """
+            <https://api.github.com/>; rel="next", <https://api.github.com/>; rel="first"
+          """)
+          initialData = [
+            GitHubUser(
+              id: 1,
+              login: "adul",
+              name: "adul adul",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+            GitHubUser(
+              id: 2,
+              login: "mike",
+              name: "mike shinoda",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+          ]
+          
+          data = [
+            GitHubUser(
+              id: 3,
+              login: "dude",
+              name: "dude marco",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+            GitHubUser(
+              id: 4,
+              login: "john",
+              name: "john ceena",
+              avatarUrl: nil,
+              reposUrl: nil,
+              type: nil,
+              followers: nil,
+              following: nil),
+          ]
+          
+          pagedObject = PagedObject(from: headerLink, with: .initial(pageLimit: 1), currentUrl: "", results: data)
+          
+          err = HTTPError.unexpectedResponse
+          
+        }
+        
+        it("should update githubUsers array") {
+          githubUserService = MockedGitHubUserService(mockPagedObject: pagedObject)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserListViewModel(githubUsersAPI: gitHubUsersAPI)
+          sut.githubUsers = initialData
+          sut.userMap = [
+            initialData[0].id!: initialData[0],
+            initialData[1].id!: initialData[1],
+          ]
+          sut.pagedObject = pagedObject
+          
+          let expected = initialData + data
+          
+          await sut.fetchMoreGitHubUserList()
+          await expect(sut.githubUsers).toEventually(equal(expected))
+        }
+        
+        it("should not update githubUsers array as the fetch failed") {
+          githubUserService = MockedGitHubUserService(mockError: err)
+          gitHubUsersAPI = GitHubUsersAPI(
+            githubUserService: githubUserService,
+            githubuserRepoService: githubUserRepoService)
+          sut = GitHubUserListViewModel(githubUsersAPI: gitHubUsersAPI)
+          sut.githubUsers = initialData
+          sut.userMap = [
+            initialData[0].id!: initialData[0],
+            initialData[1].id!: initialData[1],
+          ]
+          sut.pagedObject = pagedObject
+          
+          await sut.fetchMoreGitHubUserList()
+          await expect(sut.githubUsers).toEventually(equal(initialData))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Preparation for adding unit tests.

<h1>Additions:</h1>

Generals:
- Adding `Quick` and `Nimble` to `GitHubUsersTests` using SPM

Mocks:
- `GitHubUsersTests/MockedServices/MockedServices.swift`: mocked services classes for unit test purpose

Tests:
- `GitHubUsersTests/Utilities/StringExtensionsTests.swift`: Unit test for String Extensions
- `GitHubUsersTests/ViewModel/GitHubUserListViewModelTests.swift`: Unit test for GitHubUserListViewModel
- `GitHubUsersTests/ViewModel/GitHubUserDetailsViewModelTests.swift`: Unit test for GitHubUserDetailsViewModel

<h1>Changes:</h1>

Models:
- `Models/GitHubUser.swift`: Update GitHubUser to confront to `Equatable` protocol

Networks:
- `Network/Pagination.swift`: Fix warning

Services:
- `Services/GitHubUserRepoServices.swift`: Set public and add public initializer for GitHubUsersAPI refactoring
- `Services/GitHubUserServices.swift`: Set public and add public initializer for GitHubUsersAPI refactoring
- `Services/GitHubUsersAPI.swift`: Refactor for preparation for unit tests by using protocol name for property instead of actual class name